### PR TITLE
Fix location of fff.h

### DIFF
--- a/cmake/dependencies/fff.cmake
+++ b/cmake/dependencies/fff.cmake
@@ -3,5 +3,5 @@ file (DOWNLOAD
     # since v1.1 does not support CUSTOM_FFF_FUNCTION_TEMPLATE
     # tag fff to the latest commit (as of today)
     https://github.com/meekrosoft/fff/raw/5111c61e1ef7848e3afd3550044a8cf4405f4199/fff.h
-    ${CMAKE_INSTALL_INCLUDEDIR}/fff.h
+    ${CMAKE_BINARY_DIR}/include/fff.h
 )

--- a/cmake/dependencies/mosquitto.cmake
+++ b/cmake/dependencies/mosquitto.cmake
@@ -5,7 +5,10 @@
     #pkg_check_modules(Mosquitto IMPORTED_TARGET libmosquittopp REQUIRED)
 #endif()
 
-file (DOWNLOAD https://test.mosquitto.org/ssl/mosquitto.org.crt mosquitto.org.crt)
+file (DOWNLOAD
+   https://test.mosquitto.org/ssl/mosquitto.org.crt
+   ${CMAKE_BINARY_DIR}/demo/mosquitto.org.crt
+)
 
 #find_package(libmosquitto REQUIRED)
 


### PR DESCRIPTION
Download fff.h to <builddir>/include/fff.h

This fixes an error when building mecaps according to the procedure outlined in README.
I didn't experience this error when building mecaps outside of the source dir using QtCreator.