### PR TITLE
Fix location of mosquitto.org.crt

### DIFF
--- a/cmake/dependencies/mosquitto.cmake
+++ b/cmake/dependencies/mosquitto.cmake
@@ -5,7 +5,10 @@
     #pkg_check_modules(Mosquitto IMPORTED_TARGET libmosquittopp REQUIRED)
 #endif()
 
-file (DOWNLOAD https://test.mosquitto.org/ssl/mosquitto.org.crt mosquitto.org.crt)
+file (DOWNLOAD
+   https://test.mosquitto.org/ssl/mosquitto.org.crt
+   ${CMAKE_BINARY_DIR}/mosquitto.org.crt
+)
 
 #find_package(libmosquitto REQUIRED)
 

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -6,8 +6,19 @@ add_executable(${TARGET_NAME} src/main.cpp)
 
 target_link_libraries(${TARGET_NAME} PRIVATE ${PROJECT_NAME}_application_engine)
 
+# Deployment: Copy the mosquitto.org.cert file next to the application binary so that it's found.
+add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${CMAKE_BINARY_DIR}/mosquitto.org.crt"
+    $<TARGET_FILE_DIR:${TARGET_NAME}>
+)
+
 if (WIN32)
     target_compile_definitions(${TARGET_NAME} PRIVATE NOMINMAX)
     # Deployment: On Windows, copy the Slint DLL next to the application binary so that it's found.
-    add_custom_command(TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:${TARGET_NAME}> $<TARGET_FILE_DIR:${TARGET_NAME}> COMMAND_EXPAND_LISTS)
+    add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        $<TARGET_RUNTIME_DLLS:${TARGET_NAME}>
+        $<TARGET_FILE_DIR:${TARGET_NAME}> COMMAND_EXPAND_LISTS
+    )
 endif()


### PR DESCRIPTION
Download file to CMAKE_BINARY_DIR and copy file post build from CMAKE_BINARY_DIR to TARGET_FILE_DIR of
current target.

This fixes file location when building mecaps according to the procedure outlined in the README.
This should also fix file location when building mecaps with any multi-config CMake generator.