### PR TITLE
 Do not allow for copying singletons

### DIFF
--- a/demo/src/application_engine/application_engine.h
+++ b/demo/src/application_engine/application_engine.h
@@ -8,13 +8,17 @@ class ApplicationEngine
 {
 	friend class ApplicationEngineUnitTestHarness;
 
-  public:
-	static ApplicationEngine &init(const slint::ComponentHandle<AppWindow> &appWindow);
-
   private:
 	ApplicationEngine(const slint::ComponentHandle<AppWindow> &appWindow);
 	~ApplicationEngine();
 
+	ApplicationEngine(const ApplicationEngine&) = delete;
+	ApplicationEngine &operator=(const ApplicationEngine&) = delete;
+
+  public:
+	static ApplicationEngine &init(const slint::ComponentHandle<AppWindow> &appWindow);
+
+  private:
 	static void InitCounterDemo(const CounterSingleton &uiPageCounter);
 	static void InitHttpDemo(const HttpSingleton &httpSingleton, const INetworkAccessManager &networkAccessManager);
 	static void InitFtpDemo(const FtpSingleton &ftpSingleton, const INetworkAccessManager &networkAccessManager);

--- a/src/network_access_manager/network_access_manager.h
+++ b/src/network_access_manager/network_access_manager.h
@@ -24,6 +24,13 @@ class NetworkAccessManager : public INetworkAccessManager
 {
 	friend class NetworkAccessManagerUnitTestHarness;
 
+  private:
+	NetworkAccessManager();
+	~NetworkAccessManager();
+
+	NetworkAccessManager(const NetworkAccessManager&) = delete;
+	NetworkAccessManager &operator=(const NetworkAccessManager&) = delete;
+
   public:
 	static NetworkAccessManager &instance();
 
@@ -31,9 +38,6 @@ class NetworkAccessManager : public INetworkAccessManager
 	bool unregisterTransfer(AbstractTransferHandle &transferHandle) const final;
 
   private:
-	NetworkAccessManager();
-	~NetworkAccessManager();
-
 	static int socketCallback(CURL *handle, curl_socket_t socket, int eventType, NetworkAccessManager *self, void *);
 	static int timerCallback(CURLM *handle, long timeoutMs, Timer *timeoutTimer);
 


### PR DESCRIPTION
Delete copy constructor and copy assignment operator of singleton classes.