### PR TITLE
Configure project for testing with CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ option(BUILD_INTEGRATION_MQTT "Build MQTT Integration" ON) # this will be overri
 option(BUILD_TESTS "Build Tests" ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/ECM/find-modules")
+
+include(CTest)
 include(cmake/dependencies.cmake)
 
 set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)

--- a/cmake/dependencies/doctest.cmake
+++ b/cmake/dependencies/doctest.cmake
@@ -8,6 +8,8 @@ if (NOT doctest_FOUND)
     )
     FetchContent_MakeAvailable(doctest)
 
+    list(APPEND CMAKE_MODULE_PATH ${doctest_SOURCE_DIR}/scripts/cmake)
+
     target_include_directories(
         doctest
         INTERFACE $<BUILD_INTERFACE:${doctest_SOURCE_DIR}/doctest>

--- a/src/kdgui_slint_integration/CMakeLists.txt
+++ b/src/kdgui_slint_integration/CMakeLists.txt
@@ -26,7 +26,16 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 endif()
 
 if(BUILD_TESTS)
+    include(doctest)
     set(UNITTEST_TARGET_NAME test_${TARGET_NAME})
     add_executable(${UNITTEST_TARGET_NAME} tst_kdgui_slint_integration.cpp)
     target_link_libraries(${UNITTEST_TARGET_NAME} PRIVATE ${TARGET_NAME} doctest::doctest)
+    doctest_discover_tests(
+        ${UNITTEST_TARGET_NAME}
+        ADD_LABELS
+        1
+        PROPERTIES
+        LABELS
+        "mecaps"
+    )
 endif()

--- a/src/network_access_manager/CMakeLists.txt
+++ b/src/network_access_manager/CMakeLists.txt
@@ -14,8 +14,17 @@ target_link_libraries(${TARGET_NAME}
 )
 
 if(BUILD_TESTS)
+    include(doctest)
     set(UNITTEST_TARGET_NAME test_${TARGET_NAME})
     add_executable(${UNITTEST_TARGET_NAME} tst_network_access_manager.cpp tst_libcurl_stub.h)
     target_link_libraries(${UNITTEST_TARGET_NAME} PRIVATE ${TARGET_NAME} doctest::doctest)
+    doctest_discover_tests(
+        ${UNITTEST_TARGET_NAME}
+        ADD_LABELS
+        1
+        PROPERTIES
+        LABELS
+        "mecaps"
+    )
 endif()
 


### PR DESCRIPTION
This change includes CTest module and uses automated discovery of tests using doctest's doctest_discover_tests script.
Using this script common set-up and tear-down logic cannot be shared by multiple test cases anymore and is moved into individual test cases. We make sure that every call of NetworkAccessManager::instance() (that includes implicit calls via NetworkAccessManagerUnitTestHarness) is preceeded by setting curl_multi_init_fake.return_val to allow for proper initialization in ctor of singleton NetworkAccessManager.

We aim to have tests and their results be independent of other tests and independent of the order of execution of the tests. I had previously put in some effort to make sure this is especially the case when testing initialization of singleton NetworkAccessManager which only initializes once per lifetime and is tricky to be either deleted or 'reset'. Turns out, I have not been successfull doing so in the past. I.e. initialization test of NetworkAccessManager needs to be run before all other tests otherwise NetworkAccessManager is already initialized and the initialization test will fail. (It is okay to run other tests individually and in any order without running initialization test first.) I yet again was not successfull finding a way to have the init tests be independent of execution order. For now I suggest to accept this peculiarity which is additionaly documented as a comment in the test.