### PR TITLE
Remove obsolete include from slint.cmake

### DIFF
--- a/cmake/dependencies/slint.cmake
+++ b/cmake/dependencies/slint.cmake
@@ -10,8 +10,6 @@ if (NOT Slint_FOUND)
   set(SLINT_FEATURE_RENDERER_SKIA ON)
   set(SLINT_FEATURE_WAYLAND ON)
 
-  include(FetchContent)
-
   FetchContent_Declare(
     Slint
     GIT_REPOSITORY https://github.com/slint-ui/slint.git


### PR DESCRIPTION
We include FetchContent module for all dependencies in dependencies.cmake. No need to additionally include it in slint.cmake