### PR TITLE
Always build libcurl as shared library

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -23,7 +23,11 @@ include(FetchContent)
 include(cmake/dependencies/kdutils.cmake)
 
 if (BUILD_INTEGRATION_CURL)
+    # Ignore BUILD_SHARED_LIBS and build libcurl as shared library
+    set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
+    set(BUILD_SHARED_LIBS ON)
     include(cmake/dependencies/curl.cmake)
+    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD})
 endif()
 
 if (BUILD_INTEGRATION_MQTT)


### PR DESCRIPTION
Ignore BUILD_SHARED_LIBS and always build libcurl as shared library. We cache current value of BUILD_SHARED_LIBS, set BUILD_SHARED_LIBS ON when including curl.cmake and reset BUILD_SHARED_LIBS to it's previous value after including curl.cmake.

@MiKom I tried to set BUILD_SHARED_LIBS for the curl target individually, using set_target_properties in curl.cmake but didn't succeed. My current solution does not appear very elegant OTOHS it is very unambiguous due to it's verbosity. :)