### PR TITLE
Fix one compilation error on MSVC

### DIFF
--- a/src/kdgui_slint_integration/kdgui_slint_keys.h
+++ b/src/kdgui_slint_integration/kdgui_slint_keys.h
@@ -1,6 +1,7 @@
 #include <KDGui/kdgui_keys.h>
 #include <spdlog/spdlog.h>
 #include <slint.h>
+#include <array>
 
 using enum KDGui::Key;
 namespace sk = slint::platform::key_codes;


### PR DESCRIPTION
We use array but don't include it. Apparently the inclusion order on MSVC 2022 doesn't guarantee array. Plus "include what you use" is good practice.