### PR TITLE
Update to slint v1.3.2

### DIFF
--- a/cmake/dependencies/slint.cmake
+++ b/cmake/dependencies/slint.cmake
@@ -15,7 +15,7 @@ if (NOT Slint_FOUND)
     GIT_REPOSITORY https://github.com/slint-ui/slint.git
     # `release/1` will auto-upgrade to the latest Slint >= 1.0.0 and < 2.0.0
     # `release/1.0` will auto-upgrade to the latest Slint >= 1.0.0 and < 1.1.0
-    GIT_TAG 032032dc3eb176580b88b2ceef2e458553a58bce # v1.3.1
+    GIT_TAG 768084b68e18c8d5320eb78b756e33a1f8e136ad # v1.3.2
     SOURCE_SUBDIR api/cpp
   )
   FetchContent_MakeAvailable(Slint)


### PR DESCRIPTION
Fixes e.g. a bug that would cause MQTT topic to not be validated while typing topic name.

Changelog:
https://github.com/slint-ui/slint/blob/master/CHANGELOG.md#132---2023-12-01