### PR TITLE
Fix build when MQTT is not used

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -7,11 +7,13 @@ add_executable(${TARGET_NAME} src/main.cpp)
 target_link_libraries(${TARGET_NAME} PRIVATE ${PROJECT_NAME}_application_engine)
 
 # Deployment: Copy the mosquitto.org.cert file next to the application binary so that it's found.
-add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    "${CMAKE_BINARY_DIR}/mosquitto.org.crt"
-    $<TARGET_FILE_DIR:${TARGET_NAME}>
-)
+if(BUILD_INTEGRATION_MQTT)
+    add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_BINARY_DIR}/mosquitto.org.crt"
+        $<TARGET_FILE_DIR:${TARGET_NAME}>
+    )
+endif()
 
 if (WIN32)
     target_compile_definitions(${TARGET_NAME} PRIVATE NOMINMAX)


### PR DESCRIPTION
When mqtt integration is not enabled, we shouldn't copy the certificate because it won't be downloaded and the copy command will fail.