### PR TITLE
Improve testability of MQTT integration

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -2,13 +2,13 @@
 # TODO
 # check here if mosquitto is present for now.
 # override BUILD_INTEGRATION_MQTT accordingly.
-# remove this as soon as we support build of libmosquittopp on all OSes
+# remove this as soon as we support build of libmosquitto on all OSes
 # and we are always able to build mqtt integration in case
 # BUILD_INTEGRATION_MQTT is set to ON.
 find_package(PkgConfig)
 
 if (UNIX AND PKG_CONFIG_FOUND)
-    pkg_check_modules(Mosquitto IMPORTED_TARGET libmosquittopp REQUIRED)
+    pkg_check_modules(Mosquitto IMPORTED_TARGET libmosquitto REQUIRED)
 endif()
 
 if (Mosquitto_FOUND AND BUILD_INTEGRATION_MQTT)

--- a/demo/src/application_engine/application_engine.cpp
+++ b/demo/src/application_engine/application_engine.cpp
@@ -126,9 +126,9 @@ void ApplicationEngine::InitFtpDemo(const FtpSingleton &ftpSingleton, const INet
 void ApplicationEngine::InitMqttDemo(const MqttSingleton &mqttSingleton)
 {
 #ifdef MOSQUITTO_AVAILABLE
-	MQTT::libInit();
+	MqttLib::instance().init();
 
-	static MQTT mqttClient = MQTT("mecapitto", true, true);
+	static MqttClient mqttClient = MqttClient("mecapitto", true, true);
 
 	static std::shared_ptr<slint::VectorModel<slint::SharedString>> mqttSubscriptionsModel(new slint::VectorModel<slint::SharedString>);
 	mqttSingleton.set_subscribed_topics(mqttSubscriptionsModel);
@@ -147,42 +147,42 @@ void ApplicationEngine::InitMqttDemo(const MqttSingleton &mqttSingleton)
 
 	auto mqttTopicValidator = [&]() {
 		const auto topic = mqttSingleton.get_topic().data();
-		const auto isValid = MQTT::isValidTopicNameForSubscription(topic);
+		const auto isValid = MqttLib::instance().isValidTopicNameForSubscription(topic);
 		mqttSingleton.set_is_topic_valid(isValid);
 	};
 	mqttSingleton.on_user_edited_topic(mqttTopicValidator);
 	mqttTopicValidator(); // initial validation of default topic set above
 
-	auto translateConnectionState = [](MQTT::ConnectionState connectionState) -> MqttConnectionState {
+	auto translateConnectionState = [](MqttClient::ConnectionState connectionState) -> MqttConnectionState {
 		switch (connectionState) {
-		case MQTT::ConnectionState::CONNECTING: return MqttConnectionState::Connecting;
-		case MQTT::ConnectionState::CONNECTED: return MqttConnectionState::Connected;
-		case MQTT::ConnectionState::DISCONNECTING: return MqttConnectionState::Disconnecting;
-		case MQTT::ConnectionState::DISCONNECTED: return MqttConnectionState::Disconnected;
+		case MqttClient::ConnectionState::CONNECTING: return MqttConnectionState::Connecting;
+		case MqttClient::ConnectionState::CONNECTED: return MqttConnectionState::Connected;
+		case MqttClient::ConnectionState::DISCONNECTING: return MqttConnectionState::Disconnecting;
+		case MqttClient::ConnectionState::DISCONNECTED: return MqttConnectionState::Disconnected;
 		default:
-			spdlog::error("Cannot translate MQTT::ConnectionState {} to MqttConnectionState!");
+			spdlog::error("Cannot translate IMqttClient::ConnectionState {} to MqttConnectionState!");
 			return MqttConnectionState::Disconnected;
 		}
 	};
 
-	auto translateSubscriptionState = [](MQTT::SubscriptionState subscriptionState) -> MqttSubscriptionState {
+	auto translateSubscriptionState = [](MqttClient::SubscriptionState subscriptionState) -> MqttSubscriptionState {
 		switch (subscriptionState) {
-		case MQTT::SubscriptionState::SUBSCRIBING: return MqttSubscriptionState::Subscribing;
-		case MQTT::SubscriptionState::SUBSCRIBED: return MqttSubscriptionState::Subscribed;
-		case MQTT::SubscriptionState::UNSUBSCRIBING: return MqttSubscriptionState::Unsubscribing;
-		case MQTT::SubscriptionState::UNSUBSCRIBED: return MqttSubscriptionState::Unsubscribed;
+		case MqttClient::SubscriptionState::SUBSCRIBING: return MqttSubscriptionState::Subscribing;
+		case MqttClient::SubscriptionState::SUBSCRIBED: return MqttSubscriptionState::Subscribed;
+		case MqttClient::SubscriptionState::UNSUBSCRIBING: return MqttSubscriptionState::Unsubscribing;
+		case MqttClient::SubscriptionState::UNSUBSCRIBED: return MqttSubscriptionState::Unsubscribed;
 		default:
-			spdlog::error("Cannot translate MQTT::SubscriptionState {} to MqttSubscriptionState!");
+			spdlog::error("Cannot translate IMqttClient::SubscriptionState {} to MqttSubscriptionState!");
 			return MqttSubscriptionState::Unsubscribed;
 		}
 	};
 
-	auto onMqttConnectionStateChanged = [&](const MQTT::ConnectionState &connectionState) {
+	auto onMqttConnectionStateChanged = [&](const MqttClient::ConnectionState &connectionState) {
 		mqttSingleton.set_connection_state(translateConnectionState(connectionState));
 	};
 	mqttClient.connectionState.valueChanged().connect(onMqttConnectionStateChanged);
 
-	auto onMqttSubscriptionStateChanged = [&](const MQTT::SubscriptionState &subscriptionState) {
+	auto onMqttSubscriptionStateChanged = [&](const MqttClient::SubscriptionState &subscriptionState) {
 		mqttSingleton.set_subscription_state(translateSubscriptionState(subscriptionState));
 	};
 	mqttClient.subscriptionState.valueChanged().connect(onMqttSubscriptionStateChanged);
@@ -259,6 +259,6 @@ void ApplicationEngine::InitMqttDemo(const MqttSingleton &mqttSingleton)
 void ApplicationEngine::DeinitMqttDemo()
 {
 #ifdef MOSQUITTO_AVAILABLE
-	MQTT::libCleanup();
+	MqttLib::instance().cleanup();
 #endif
 }

--- a/src/mqtt/mosquitto_wrapper.h
+++ b/src/mqtt/mosquitto_wrapper.h
@@ -1,0 +1,188 @@
+/*
+ * This file implements C++ wrappers around the mosquitto C library.
+ *
+ * The classes implemented in this file differ from mosquittopp,
+ * a wrapper class maintained in the Eclipse mosquitto repository,
+ * in respect to the following aspects:
+ * - library and client functions are separated into individual classes
+ * - all functions are virtual for the purpose of convenient mocking
+ * - some functions wrapped by mosquittopp are not wrapped here [1]
+ * - some functions wrapped here are not wrapped by mosquittopp [1]
+ * - mosquitto event callbacks are exposed as KDBindings::Signals
+ *
+ * [1] as of January 2024
+ */
+
+#pragma once
+
+#include <kdbindings/signal.h>
+#include <mosquitto.h>
+#include <optional>
+#include <string>
+#include <string_view>
+
+/*
+ * This is a C++ class wrapping library specific functions
+ * of the mosquitto C library.
+ */
+class MosquittoLib
+{
+  private:
+	MosquittoLib() = default;
+	~MosquittoLib() = default;
+
+	MosquittoLib(const MosquittoLib&) = delete;
+	MosquittoLib &operator=(const MosquittoLib&) = delete;
+
+  public:
+	static MosquittoLib &instance() {
+		static MosquittoLib instance;
+		return instance;
+	}
+
+	virtual int init() {
+		return mosquitto_lib_init();
+	}
+
+	virtual int cleanup() {
+		return mosquitto_lib_cleanup();
+	}
+
+	virtual int version(int *major, int *minor, int *revision) const {
+		return mosquitto_lib_version(major, minor, revision);
+	}
+
+	[[nodiscard]] virtual std::string_view connackString(int connack_code) const {
+		return mosquitto_connack_string(connack_code);
+	}
+
+	[[nodiscard]] virtual std::string_view errorString(int mosq_errno) const {
+		return mosquitto_strerror(mosq_errno);
+	}
+
+	[[nodiscard]] virtual std::string_view reasonString(int reason_code) const {
+		return mosquitto_reason_string(reason_code);
+	}
+
+	[[nodiscard]] virtual bool isValidTopicNameForSubscription(const std::string &topic) const {
+		const auto result = mosquitto_sub_topic_check(topic.c_str());
+		return (result == MOSQ_ERR_SUCCESS);
+	}
+};
+
+/*
+ * This is a C++ class wrapping client specific functions
+ * of the mosquitto C library.
+ */
+class MosquittoClient
+{
+  public:
+	MosquittoClient(const std::string &clientId, bool clean_session = true) {
+		m_clientInstance = mosquitto_new(clientId.c_str(), clean_session, this);
+
+		mosquitto_connect_callback_set(m_clientInstance, onConnect);
+		mosquitto_disconnect_callback_set(m_clientInstance, onDisconnect);
+		mosquitto_publish_callback_set(m_clientInstance, onPublish);
+		mosquitto_message_callback_set(m_clientInstance, onMessage);
+		mosquitto_subscribe_callback_set(m_clientInstance, onSubscribe);
+		mosquitto_unsubscribe_callback_set(m_clientInstance, onUnsubscribe);
+		mosquitto_log_callback_set(m_clientInstance, onLog);
+	}
+
+	~MosquittoClient() {
+		mosquitto_destroy(m_clientInstance);
+	}
+
+	virtual int connect(const std::string &host, int port, int keepalive) {
+		return mosquitto_connect(m_clientInstance, host.c_str(), port, keepalive);
+	}
+
+	virtual int disconnect() {
+		return mosquitto_disconnect(m_clientInstance);
+	}
+
+	virtual int publish(int *msg_id, const std::string &topic, int payloadlen = 0, const void *payload = nullptr, int qos = 0, bool retain = false) {
+		return mosquitto_publish(m_clientInstance, msg_id, topic.c_str(), payloadlen, payload, qos, retain);
+	}
+
+	virtual int subscribe(int *msg_id, const std::string &sub, int qos = 0) {
+		return mosquitto_subscribe(m_clientInstance, msg_id, sub.c_str(), qos);
+	}
+
+	virtual int unsubscribe(int *msg_id, const std::string &sub) {
+		return mosquitto_unsubscribe(m_clientInstance, msg_id, sub.c_str());
+	}
+
+	virtual int loopMisc() {
+		return mosquitto_loop_misc(m_clientInstance);
+	}
+
+	virtual int loopRead(int max_packets = 1) {
+		return mosquitto_loop_read(m_clientInstance, max_packets);
+	}
+
+	virtual int loopWrite(int max_packets = 1) {
+		return mosquitto_loop_write(m_clientInstance, max_packets);
+	}
+
+	virtual int socket() {
+		return mosquitto_socket(m_clientInstance);
+	}
+
+	virtual bool wantWrite() {
+		return mosquitto_want_write(m_clientInstance);
+	}
+
+	virtual void *sslGet() {
+		return mosquitto_ssl_get(m_clientInstance);
+	}
+
+	virtual int tlsSet(const std::string &cafile, std::optional<const std::string> &capath, std::optional<const std::string> &certfile, std::optional<const std::string> &keyfile, int (*pw_callback)(char *buf, int size, int rwflag, void *userdata) = nullptr) {
+		return mosquitto_tls_set(m_clientInstance, cafile.c_str(), capath ? capath->c_str() : nullptr, certfile ? certfile->c_str() : nullptr, keyfile ? keyfile->c_str() : nullptr, pw_callback);
+	}
+
+	virtual int usernamePasswordSet(const std::string &username, const std::string &password) {
+		return mosquitto_username_pw_set(m_clientInstance, username.c_str(), password.c_str());
+	}
+
+	virtual int willSet(const std::string &topic, int payloadlen = 0, const void *payload = nullptr, int qos = 0, bool retain = false) {
+		return mosquitto_will_set(m_clientInstance, topic.c_str(), payloadlen, payload, qos, retain);
+	}
+
+	KDBindings::Signal<int /*connackCode*/> connected;
+	KDBindings::Signal<int /*reasonCode*/> disconnected;
+	KDBindings::Signal<int /*msgId*/> published;
+	KDBindings::Signal<const struct mosquitto_message * /*msg*/> message;
+	KDBindings::Signal<int /*msgId*/, int /*qosCount*/, const int * /*grantedQos*/> subscribed;
+	KDBindings::Signal<int /*msgId*/> unsubscribed;
+	KDBindings::Signal<int /*level*/, const char * /*str*/> log;
+	KDBindings::Signal<> error;
+
+  private:
+	static void onConnect([[maybe_unused]] struct mosquitto *client, void *self, int connackCode) {
+		static_cast<MosquittoClient*>(self)->connected.emit(connackCode);
+	}
+	static void onDisconnect([[maybe_unused]] struct mosquitto *client, void *self, int reasonCode) {
+		static_cast<MosquittoClient*>(self)->disconnected.emit(reasonCode);
+	}
+	static void onPublish([[maybe_unused]] struct mosquitto *client, void *self, int msgId) {
+		static_cast<MosquittoClient*>(self)->published.emit(msgId);
+	}
+	static void onMessage([[maybe_unused]] struct mosquitto *client, void *self, const struct mosquitto_message *message) {
+		static_cast<MosquittoClient*>(self)->message.emit(message);
+	}
+	static void onSubscribe([[maybe_unused]] struct mosquitto *client, void *self, int msg_id, int qos_count, const int *granted_qos) {
+		static_cast<MosquittoClient*>(self)->subscribed.emit(msg_id, qos_count, granted_qos);
+	}
+	static void onUnsubscribe([[maybe_unused]] struct mosquitto *client, void *self, int msg_id) {
+		static_cast<MosquittoClient*>(self)->unsubscribed.emit(msg_id);
+	}
+	static void onLog([[maybe_unused]] struct mosquitto *client, void *self, int level, const char *str) {
+		static_cast<MosquittoClient*>(self)->log.emit(level, str);
+	}
+	static void onError([[maybe_unused]] struct mosquitto *client, void *self) {
+		static_cast<MosquittoClient*>(self)->error.emit();
+	}
+
+	struct mosquitto *m_clientInstance;
+};

--- a/src/mqtt/mqtt.h
+++ b/src/mqtt/mqtt.h
@@ -4,12 +4,84 @@
 #include <KDFoundation/timer.h>
 #include <KDUtils/file.h>
 #include <KDUtils/url.h>
-#include <mosquittopp.h>
+#include "mosquitto_wrapper.h"
 
 using namespace KDFoundation;
 using namespace KDUtils;
 
-class MQTT : private mosqpp::mosquittopp
+constexpr int c_defaultPort = 1883;
+constexpr int c_defaultKeepAliveSeconds = 60;
+
+/*
+ * Class: IMqttLib
+ *
+ * This is an abstract C++ class specifing a generic
+ * interface exposed to application / business logic
+ * to access MQTT library implementations.
+ */
+class IMqttLib
+{
+  protected:
+	IMqttLib() = default;
+	virtual ~IMqttLib() {}
+
+  public:
+	IMqttLib(const IMqttLib&) = delete;
+	IMqttLib &operator=(const IMqttLib&) = delete;
+
+	virtual int init() = 0;
+	virtual int cleanup() = 0;
+
+	[[nodiscard]] virtual bool isInitialized() const = 0;
+	virtual bool isValidTopicNameForSubscription(const std::string &topic) = 0;
+};
+
+/*
+ * Class: MqttLib
+ *
+ * This class exposes mosquitto library functions to
+ * the application / business logic.
+ */
+class MqttLib : public IMqttLib
+{
+	friend class MqttClient;
+	friend class MqttUnitTestHarness;
+
+  private:
+	MqttLib();
+	~MqttLib() = default;
+
+  public:
+	static MqttLib &instance();
+
+	int init() override;
+	int cleanup() override;
+
+	[[nodiscard]] bool isInitialized() const override;
+	bool isValidTopicNameForSubscription(const std::string &topic) override;
+
+  protected:
+	int version(int *major, int *minor, int *revision);
+
+	bool checkMosquittoResultAndDoDebugPrints(int result, std::string_view func = {});
+
+	std::string_view connackString(int connackCode);
+	std::string_view errorString(int errorCode);
+	std::string_view reasonString(int reasonCode);
+
+  private:
+	MosquittoLib *m_mosquittoLib;
+	bool m_isInitialized;
+};
+
+/*
+ * Class: IMqttClient
+ *
+ * This is an abstract C++ class specifing a generic
+ * interface exposed to application / business logic
+ * to access MQTT client implementations.
+ */
+class IMqttClient
 {
   public:
 	enum class ConnectionState {
@@ -26,65 +98,130 @@ class MQTT : private mosqpp::mosquittopp
 		UNSUBSCRIBED
 	};
 
-	static int libInit();
-	static int libCleanup();
-
-	MQTT(const std::string &clientId, bool cleanSession = true, bool verbose = false);
-	~MQTT();
-
 	KDBindings::Property<ConnectionState> connectionState { ConnectionState::DISCONNECTED };
 	KDBindings::Property<SubscriptionState> subscriptionState { SubscriptionState::UNSUBSCRIBED };
 
 	KDBindings::Property<std::vector<std::string>> subscriptions { };
 
-	KDBindings::Signal<int> msgPublished;
-	KDBindings::Signal<const mosquitto_message *> msgReceived;
+	KDBindings::Signal<int /*msgId*/> msgPublished;
+	KDBindings::Signal<const mosquitto_message * /*msg*/> msgReceived;
 
 	KDBindings::Signal<> error;
 
-	int setTls(const File &cafile);
-	int setUsernameAndPassword(const std::string &username, const std::string &password);
-	int setWill(const std::string &topic, int payloadlen = 0, const void *payload = NULL, int qos = 0, bool retain = false);
+	virtual int setTls(const File &cafile) = 0;
+	virtual int setUsernameAndPassword(const std::string &username, const std::string &password) = 0;
+	virtual int setWill(const std::string &topic, int payloadlen = 0, const void *payload = nullptr, int qos = 0, bool retain = false) = 0;
 
-	int connect(const Url &host, int port = 1883, int keepalive = 60);
-	int disconnect();
+	virtual int connect(const Url &host, int port = c_defaultPort, int keepalive = c_defaultKeepAliveSeconds) = 0;
+	virtual int disconnect() = 0;
 
-	int publish(int *msgId, const char *topic, int payloadlen = 0, const void *payload = NULL, int qos = 0, bool retain = false);
+	virtual int publish(int *msgId, const char *topic, int payloadlen = 0, const void *payload = nullptr, int qos = 0, bool retain = false) = 0;
 
-	int subscribe(const char *pattern, int qos = 0);
-	int unsubscribe(const char *pattern);
+	virtual int subscribe(const char *pattern, int qos = 0) = 0;
+	virtual int unsubscribe(const char *pattern) = 0;
+};
 
-	static bool isValidTopicNameForSubscription(std::string_view topic);
+/*
+ * Class: MqttClient
+ *
+ * This class exposes mosquitto client functions to
+ * the application / business logic.
+ */
+class MqttClient : public IMqttClient
+{
+	friend class MqttUnitTestHarness;
+
+  public:
+	MqttClient(const std::string &clientId, bool cleanSession = true, bool verbose = false);
+	~MqttClient() = default;
+
+	int setTls(const File &cafile) override;
+	int setUsernameAndPassword(const std::string &username, const std::string &password) override;
+	int setWill(const std::string &topic, int payloadlen = 0, const void *payload = nullptr, int qos = 0, bool retain = false) override;
+
+	int connect(const Url &host, int port = c_defaultPort, int keepalive = c_defaultKeepAliveSeconds) override;
+	int disconnect() override;
+
+	int publish(int *msgId, const char *topic, int payloadlen = 0, const void *payload = nullptr, int qos = 0, bool retain = false) override;
+
+	int subscribe(const char *pattern, int qos = 0) override;
+	int unsubscribe(const char *pattern) override;
 
   private:
-	virtual void on_connect(int connackCode) override;
-//	virtual void on_connect_with_flags(int returnCode, int flags) override;
-	virtual void on_disconnect(int reasonCode) override;
-	virtual void on_publish(int msgId) override;
-	virtual void on_message(const struct mosquitto_message *message) override;
-	virtual void on_subscribe(int msgId, int qos_count, const int *granted_qos) override;
-	virtual void on_unsubscribe(int msgId) override;
-	virtual void on_log(int level, const char *str) override;
-	virtual void on_error() override;
-
-	void hookToEventLoop();
-	void unhookFromEventLoop();
-
-	void onFileDescriptorNotifierTriggeredRead();
-	void onFileDescriptorNotifierTriggeredWrite();
-	void onMiscTaskTimerTriggered();
-
-	static bool checkMosquitoppResultAndDoDebugPrints(int result, std::string_view func = {});
-
-	std::unique_ptr<FileDescriptorNotifier> m_fdnRead;
-	std::unique_ptr<FileDescriptorNotifier> m_fdnWrite;
-	std::unique_ptr<Timer> m_miscTaskTimer;
 	bool m_verbose;
 
-	static bool s_isLibInitialized;
+	/*
+	 * Mosquitto client event handlers
+	 */
+	void onConnected(int connackCode);
+	void onDisconnected(int reasonCode);
+	void onPublished(int msgId);
+	void onMessage(const struct mosquitto_message *message);
+	void onSubscribed(int msgId, int qosCount, const int *grantedQos);
+	void onUnsubscribed(int msgId);
+	void onLog(int level, const char *str) const;
+	void onError();
 
+	/*
+	 * Event loop handlers
+	 */
+	void onReadOpRequested();
+	void onWriteOpRequested();
+	void onMiscTaskRequested();
+
+	/*
+	 * This struct modularizes the mechanism to hook mosquitto's
+	 * so called Network Loop to the application's event loop.
+	 * This is done by monitoring the client's network socket
+	 * using FileDescriptorNotifiers and having an additional
+	 * timer to trigger cyclic misc tasks.
+	 */
+	struct EventLoopHook
+	{
+	  public:
+		void init(std::chrono::milliseconds miscTaskInterval, MqttClient *parent);
+
+		void engage(int socket);
+		void disengage();
+
+		[[nodiscard]] bool isSetup() const;
+		[[nodiscard]] bool isEngaged() const;
+
+	  private:
+		std::unique_ptr<FileDescriptorNotifier> readOpNotifier;
+		std::unique_ptr<FileDescriptorNotifier> writeOpNotifier;
+		std::unique_ptr<Timer> miscTaskTimer;
+		MqttClient *parent { nullptr };
+	};
+	EventLoopHook m_eventLoopHook;
+
+	/*
+	 * This struct modularizes the dependency to the mosquitto
+	 * library's client implementation.
+	 * It owns the mosquitto client instance and is responsible
+	 * for initializing MqttClient with the provided mosquitto
+	 * client instance.
+	 * This is also relevant when passing a mosquitto client mock
+	 * for unit testing.
+	 */
+	struct MosquittoClientDependency
+	{
+	  public:
+		void init(MosquittoClient *client, MqttClient *parent);
+		MosquittoClient *client();
+
+	  private:
+		MosquittoClient* mosquittoClient { nullptr };
+	};
+	MosquittoClientDependency m_mosquitto;
+
+	/*
+	 * This struct modularizes the registry maintaining all
+	 * subscriptions to MQTT topics this MqttClient has.
+	 */
 	struct SubscriptionsRegistry
 	{
+	  public:
 		void registerPendingRegistryOperation(std::string_view topic, int msgId);
 		std::string registerTopicSubscriptionAndReturnTopicName(int msgId, int grantedQos);
 		std::string unregisterTopicSubscriptionAndReturnTopicName(int msgId);
@@ -92,6 +229,7 @@ class MQTT : private mosqpp::mosquittopp
 		std::vector<std::string> subscribedTopics() const;
 		int grantedQosForTopic(const std::string &topic) const;
 
+	  private:
 		std::unordered_map<std::string,int> qosByTopicOfActiveSubscriptions;
 		std::unordered_map<int,std::string> topicByMsgIdOfPendingOperations;
 	};


### PR DESCRIPTION
Adds our own C++ wrappers around the mosquitto C library. The new classes implemented in the mosquitto_wrapper file differ from mosquittopp, a wrapper class maintained in the Eclipse mosquitto repository, in respect to the following aspects:
- library and client functions are separated into individual classes
- all functions are virtual for the purpose of convenient mocking
- some functions wrapped by mosquittopp are not wrapped here [1]
- some functions wrapped here are not wrapped by mosquittopp [1]
- mosquitto event callbacks are exposed as KDBindings::Signal [1] as of January 2024

Add classes specifying a generic interface for MQTT library and MQTT client implementations: IMqttLib, IMqttClient.

Divide previous MQTT implementation into classes MqttLibrary and MqttClient which both inherit from the new interface classes.

Modularize some MqttClient code into seperate structs: EventLoopHook, MosquittoClientDependency.

Fix some clang-tidy warnings.