### PR TITLE
Inject dependency MQTT into ApplicationEngine::InitMqttDemo

### DIFF
--- a/demo/src/application_engine/application_engine.h
+++ b/demo/src/application_engine/application_engine.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include "app_window.h"
+#ifdef MOSQUITTO_AVAILABLE
+#include "mqtt.h"
+#endif
+#ifdef CURL_AVAILABLE
 #include "network_access_manager.h"
+#endif
 #include "slint.h"
 
 class ApplicationEngine
@@ -20,8 +25,11 @@ class ApplicationEngine
 
   private:
 	static void InitCounterDemo(const CounterSingleton &uiPageCounter);
+#ifdef CURL_AVAILABLE
 	static void InitHttpDemo(const HttpSingleton &httpSingleton, const INetworkAccessManager &networkAccessManager);
 	static void InitFtpDemo(const FtpSingleton &ftpSingleton, const INetworkAccessManager &networkAccessManager);
-	static void InitMqttDemo(const MqttSingleton &mqttSingleton);
-	static void DeinitMqttDemo();
+#endif
+#ifdef MOSQUITTO_AVAILABLE
+	static void InitMqttDemo(const MqttSingleton &mqttSingleton, IMqttClient &mqttClient);
+#endif
 };


### PR DESCRIPTION
This allows for easy injection of mocked dependency and therefore improves testability of class ApplicationEngine.