### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+#
+# SPDX-License-Identifier: MIT
+
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+          #- ubuntu-20.04
+          - windows-2022
+          #- windows-2019
+          #- macos-12
+          #- macos-11
+        build_type:
+          - Debug
+          - Release
+    env:
+      SLINT_VERSION: 1.4.1
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install ninja-build tool
+        uses: turtlesec-no/get-ninja@main
+
+      - name: Make sure MSVC is found when Ninja generator is in use
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update -qq
+          sudo apt install -y libxkbcommon-dev libxcb-xkb-dev \
+          libxkbcommon-x11-dev wayland-scanner++ wayland-protocols \
+          libwayland-dev xvfb libmosquittopp-dev libinput10
+
+      - name: Download Slint (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          wget --quiet https://github.com/slint-ui/slint/releases/download/v$SLINT_VERSION/Slint-cpp-$SLINT_VERSION-Linux-x86_64.tar.gz
+          mkdir $HOME/slint
+          tar xf Slint-cpp-$SLINT_VERSION-Linux-x86_64.tar.gz -C $HOME/slint --strip-components=1
+          echo "SLINT_INSTALL_LOCATION=$HOME/slint" >> $GITHUB_ENV
+
+      - name: Download Slint (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          curl --no-progress-meter --location --remote-name `
+            https://github.com/slint-ui/slint/releases/download/v$env:SLINT_VERSION/Slint-cpp-$env:SLINT_VERSION-win64.exe
+          & .\Slint-cpp-$env:SLINT_VERSION-win64.exe /S /D=c:\slint
+          Write-Output "SLINT_INSTALL_LOCATION=c:\slint" >> $env:GITHUB_ENV
+
+      # Tests build only on Linux right now
+      - name: Configure project
+        run: >
+          cmake -S . -B ./build -G Ninja
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DBUILD_TESTS=${{ matrix.os == 'Linux' && matrix.build_type == 'Debug'}}
+          -DCMAKE_PREFIX_PATH=${{ env.SLINT_INSTALL_LOCATION }}
+
+      - name: Build Project
+        run: cmake --build ./build
+
+# Tests turned off due to linker errors on Windows
+#      - name: Run tests on Windows/macOS
+#        if: ${{ matrix.build_type == 'Debug' && runner.os != 'Linux' }}
+#        run: ctest --test-dir ./build -C ${{ matrix.build_type }} --output-on-failure
+
+      - name: Run tests on Linux
+        if: ${{ matrix.build_type == 'Debug' && runner.os == 'Linux' }}
+        run: ctest --test-dir ./build -C ${{ matrix.build_type }} --output-on-failure
+
+      - name: Read tests log when it fails
+        uses: andstor/file-reader-action@v1
+        if: ${{ failure() && matrix.build_type == 'Debug' }}
+        with:
+          path: "./build/Testing/Temporary/LastTest.log"

--- a/cmake/dependencies/slint.cmake
+++ b/cmake/dependencies/slint.cmake
@@ -3,12 +3,10 @@ find_package(Slint QUIET)
 if (NOT Slint_FOUND)
   message("Slint could not be located in the CMake module search path. Downloading it from Git and building it locally")
 
-  set(SLINT_FEATURE_EXPERIMENTAL ON)
   # set(SLINT_FEATURE_BACKEND_WINIT OFF) # this removes X11 support
   set(SLINT_FEATURE_BACKEND_QT OFF)
   set(SLINT_FEATURE_BACKEND_WINIT_WAYLAND ON)
   set(SLINT_FEATURE_RENDERER_SKIA ON)
-  set(SLINT_FEATURE_WAYLAND ON)
 
   FetchContent_Declare(
     Slint


### PR DESCRIPTION
Based on the ones in KDUtils. Building and running tests on Windows is disabled as the mocking framework causes linker errors.

We're using pre-built Slint to speed up the build.