### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           - Debug
           - Release
     env:
-      SLINT_VERSION: 1.4.1
+      SLINT_VERSION: 1.5.1
 
     steps:
       - name: Checkout sources
@@ -39,9 +39,11 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt update -qq
-          sudo apt install -y libxkbcommon-dev libxcb-xkb-dev \
-          libxkbcommon-x11-dev wayland-scanner++ wayland-protocols \
-          libwayland-dev xvfb libmosquittopp-dev libinput10
+          sudo apt install -y \
+          libinput10 libmosquittopp-dev \
+          libwayland-dev wayland-scanner++ wayland-protocols \
+          libxkbcommon-dev libxkbcommon-x11-dev libxcb-xkb-dev xvfb \
+          qtbase5-dev
 
       - name: Download Slint (Linux)
         if: runner.os == 'Linux'

--- a/cmake/dependencies/curl.cmake
+++ b/cmake/dependencies/curl.cmake
@@ -7,7 +7,7 @@ if (NOT TARGET CURL::libcurl)
     FetchContent_Declare(
         curl
         GIT_REPOSITORY https://github.com/curl/curl.git
-        GIT_TAG curl-8_6_0
+        GIT_TAG curl-8_7_1
     )
     set(BUILD_TESTING OFF CACHE BOOL "Turn off testing" FORCE)
     set(BUILD_CURL_EXE OFF CACHE BOOL "Turn off curl executable" FORCE)

--- a/cmake/dependencies/doctest.cmake
+++ b/cmake/dependencies/doctest.cmake
@@ -4,7 +4,7 @@ if (NOT doctest_FOUND)
     FetchContent_Declare(
         doctest
         GIT_REPOSITORY https://github.com/doctest/doctest.git
-        GIT_TAG v2.4.9
+        GIT_TAG v2.4.11
     )
     FetchContent_MakeAvailable(doctest)
 

--- a/cmake/dependencies/slint.cmake
+++ b/cmake/dependencies/slint.cmake
@@ -13,7 +13,7 @@ if (NOT Slint_FOUND)
     GIT_REPOSITORY https://github.com/slint-ui/slint.git
     # `release/1` will auto-upgrade to the latest Slint >= 1.0.0 and < 2.0.0
     # `release/1.0` will auto-upgrade to the latest Slint >= 1.0.0 and < 1.1.0
-    GIT_TAG 0984170cb3e2effb2c788238bdc42c53109966fa # v1.4.1
+    GIT_TAG v1.5.1
     SOURCE_SUBDIR api/cpp
   )
   FetchContent_MakeAvailable(Slint)


### PR DESCRIPTION
Curl -> v8.7.1
https://curl.se/changes.html#8_7_1

Doctest -> v2.4.11
https://github.com/doctest/doctest/blob/master/CHANGELOG.md#v2411-2023-03-15

Slint -> v1.5.1
https://github.com/slint-ui/slint/blob/master/CHANGELOG.md#151---2024-03-20

CI -> use slint 1.5.1, install qtbase5-dev and reorder pkgs in apt install cmd