### PR TITLE
build: add Dockerfile + VS code dev container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "MECAPS Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		"dockerfile": "../Dockerfile"
+	},
+
+	// Docker root-less Setup (use this in case your host runs root-less Docker)
+	// - changes container user from default user to root which maps to host user
+	// -> https://docs.docker.com/engine/security/rootless/#how-it-works
+	"containerUser": "root",
+
+	// X11 | Wayland Setup
+	// - mounts UDS directory to allow for running GUIs from inside the container
+	// - set environment variables non-statically (using `remoteEnv` instead of `containerEnv`)
+
+	//// X11 (use this in case your host runs X11)
+	"mounts": [ "source=/tmp/.X11-unix/,target=/tmp/.X11-unix/,type=bind" ],
+	"remoteEnv": {
+		"DISPLAY": "${localEnv:DISPLAY}",
+		"XDG_RUNTIME_DIR": "/run/user/${localEnv:UID}"
+	},
+
+	//// Wayland (use this in case your host runs Wayland)
+	// "mounts": [ "source=${localEnv:XDG_RUNTIME_DIR}/${localEnv:WAYLAND_DISPLAY},target=/tmp/${localEnv:WAYLAND_DISPLAY},type=bind" ],
+	// "remoteEnv": {
+	// 	"QT_QPA_PLATFORM": "wayland",
+	// 	"WAYLAND_DISPLAY": "${localEnv:WAYLAND_DISPLAY}",
+	// 	"XDG_RUNTIME_DIR": "/tmp"
+	// },
+	
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"llvm-vs-code-extensions.vscode-clangd",
+				"ms-vscode.cmake-tools",
+                "ms-vscode.cpptools",
+				"Slint.slint",
+				"vadimcn.vscode-lldb"
+			]
+		}
+	}
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update --quiet && \
+    apt-get install --assume-yes \
+    # minimal build essentials
+    cmake \
+    curl \
+    g++ \
+    gdb \
+    git \
+    ninja-build \
+    wget \
+    # mecaps / kdutils specific pkgs
+    libcurlpp-dev \
+    libmosquittopp-dev \
+    libwayland-dev \
+    wayland-scanner++ \
+    wayland-protocols \
+    # slint specific pkgs
+    libfontconfig-dev \
+    libxcb-shape0-dev \
+    libxcb-xfixes0-dev \
+    libxcb-xkb-dev \
+    libxkbcommon-dev \
+    libxkbcommon-x11-dev \
+    qtbase5-dev
+
+# Install slint from binary
+ARG SLINT_VERSION=1.7.0
+ENV SLINT_INSTALL_DIR=/usr/src/slint
+WORKDIR $SLINT_INSTALL_DIR
+RUN wget --quiet -O - https://github.com/slint-ui/slint/releases/download/v$SLINT_VERSION/Slint-cpp-$SLINT_VERSION-Linux-x86_64.tar.gz | tar xvzf - --strip-components=1
+
+# Set CMake prefix path
+ENV CMAKE_PREFIX_PATH=$SLINT_INSTALL_DIR
+
+# Add non-root user and set as default user
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+    # [Optional] If you need to install software after connecting.
+    # && apt-get update \
+    # && apt-get install -y sudo \
+    # && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    # && chmod 0440 /etc/sudoers.d/$USERNAME
+
+USER $USERNAME


### PR DESCRIPTION
Adds Dockerfile to provide a container running Debian with all required packages installed to build and run mecaps demo application.

Adds devcontainer.json so that Dockerfile can be used as dev container in VS code.

Tested on Debian 12 running X11 with:
- VS code version 1.89.1
- Docker version 26.1.3 (running as rootless) https://docs.docker.com/engine/security/rootless/